### PR TITLE
Add materialspec/extptr paths

### DIFF
--- a/USHMM/ehri3-ushmm.properties
+++ b/USHMM/ehri3-ushmm.properties
@@ -35,6 +35,7 @@ did/physdesc/=extentAndMedium
 did/physdesc/genreform/=extentAndMedium
 did/physdesc/extent/=extentAndMedium
 did/physdesc/dimensions/=extentAndMedium
+did/materialspec/extptr/@extptrhref=ref
 altformavail/p/=locationOfCopies
 originalsloc/p/=locationOfOriginals
 did/note/p/=notes
@@ -81,3 +82,4 @@ controlaccess/p/genreform/=genreAccessPoint
 #attributes
 @level=levelOfDesc
 @langcode=languagecode
+@href=extptrhref


### PR DESCRIPTION
This captures the item's USHMM URL to the `ref` attribute of the unit description.